### PR TITLE
chore(flake/nixpkgs): `0e251e24` -> `2c423e03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`92ae1534`](https://github.com/NixOS/nixpkgs/commit/92ae1534824280564fd087b3dfa60c4147f3a063) | `` prometheus: 3.13.2 -> 3.14.0 ``                                                              |
| [`14176b6b`](https://github.com/NixOS/nixpkgs/commit/14176b6b0f774c9b83e511ccf1841a72180a6a79) | `` python3Packages.intellifire4py: 4.5.1 -> 4.5.4 ``                                            |
| [`06feeac1`](https://github.com/NixOS/nixpkgs/commit/06feeac1b78391f06da4bdb8712c21bf894c45d9) | `` python3Packages.caido-sdk-client: 0.2.0 -> 0.3.1 ``                                          |
| [`b78e0e15`](https://github.com/NixOS/nixpkgs/commit/b78e0e15bca3c0e80dd668c5ba3eae11a451400d) | `` python3Packages.caido-schema-proxy: 0.57.1 -> 0.58.0 ``                                      |
| [`9df9ad01`](https://github.com/NixOS/nixpkgs/commit/9df9ad01b729e51982e1925f632bd35572ec3117) | `` gl-gsync-demo: fix invalid unstable version scheme ``                                        |
| [`3d42d5bd`](https://github.com/NixOS/nixpkgs/commit/3d42d5bd6aaf9d2376a89ebba36a0017795c644f) | `` python3Packages.xstatic-font-awesome: fix homepage ``                                        |
| [`dc8146a5`](https://github.com/NixOS/nixpkgs/commit/dc8146a5631c4c559f42709e6923ef7b4de03424) | `` terraform-providers.huaweicloud_huaweicloud: 1.96.1 -> 1.97.1 ``                             |
| [`1468c692`](https://github.com/NixOS/nixpkgs/commit/1468c69235bc7bc6d013530f43a07b60721b3ceb) | `` quark: Fix invalid unstable version scheme ``                                                |
| [`582eaa82`](https://github.com/NixOS/nixpkgs/commit/582eaa82f2a9b3a2c21bac2d23bb8e829c5ff556) | `` ungoogled-chromium: 151.0.7922.169-1 -> 151.0.7922.173-1 ``                                  |
| [`572814f1`](https://github.com/NixOS/nixpkgs/commit/572814f122b4b2f375e2b11e166cc94d7e97cfd9) | `` beamPackages.lfe: 2.2.0 -> 2.2.2 ``                                                          |
| [`3e7bc0a3`](https://github.com/NixOS/nixpkgs/commit/3e7bc0a3e6d1952b46ffdeb889866d25cad28a14) | `` beamPackages.expert: 0.1.8 -> 0.1.9 ``                                                       |
| [`5899011f`](https://github.com/NixOS/nixpkgs/commit/5899011f4f04d85b2e28d3eb3ed3b9bda98ab2e3) | `` nginxModules.lua: add nixosTests.nginx-lua to passthru.tests ``                              |
| [`69796c0e`](https://github.com/NixOS/nixpkgs/commit/69796c0e780e0e724b90f172223d882311a299cd) | `` python3Packages.llama-index-workflows: 2.23.0 -> 2.23.2 ``                                   |
| [`4326adcd`](https://github.com/NixOS/nixpkgs/commit/4326adcdcf0eb52931dcd65234a731009a2bf073) | `` maia3: document postPatch ``                                                                 |
| [`1acb7001`](https://github.com/NixOS/nixpkgs/commit/1acb700162ea3e4e791b207436ca9835bfb9f616) | `` par-lang: 0-unstable-2026-07-29 -> 0-unstable-2026-08-20 ``                                  |
| [`5acbc090`](https://github.com/NixOS/nixpkgs/commit/5acbc090bbdf262b0a0be6d580840483ade0705c) | `` gccNGPackages.libgfortran: Fix patch conflict with `system-libbacktrace` ``                  |
| [`c7c777c2`](https://github.com/NixOS/nixpkgs/commit/c7c777c24e2d6735e5319e7ff66a1e136f6423d7) | `` python3Packages.tt-flash: relax pyluwen ``                                                   |
| [`22488105`](https://github.com/NixOS/nixpkgs/commit/2248810528f55d7881557b0d783455de2a304544) | `` tt-topology: migrate to finalAttrs ``                                                        |
| [`c8de0e90`](https://github.com/NixOS/nixpkgs/commit/c8de0e90482f0b24cfe440a5a3f98ab9430ce7d1) | `` tt-topology: relax pyluwen ``                                                                |
| [`94e6da09`](https://github.com/NixOS/nixpkgs/commit/94e6da094c2f13ed5a7082282630b6f97186055c) | `` tt-smi: 6.2.0 -> 6.2.1 ``                                                                    |
| [`bc156c59`](https://github.com/NixOS/nixpkgs/commit/bc156c59cf40f374fb7347bea93870eb7ae79ec2) | `` zellijPlugins.vim-zellij-navigator: fix build on darwin ``                                   |
| [`30ffe090`](https://github.com/NixOS/nixpkgs/commit/30ffe0900a011893bc037182902efcabb001d097) | `` zellijPlugins.workspace: fix build on darwin ``                                              |
| [`ea94b830`](https://github.com/NixOS/nixpkgs/commit/ea94b83076750e74aabf245dcdeac02a87940e3e) | `` zellijPlugins.jbz: fix build on darwin ``                                                    |
| [`9bac61a7`](https://github.com/NixOS/nixpkgs/commit/9bac61a75ed11b6805cd056884723818d6527fa4) | `` fatou: 0.6.0 -> 0.15.0 ``                                                                    |
| [`e190c538`](https://github.com/NixOS/nixpkgs/commit/e190c53894459aeb787816138fad1d4e235cd12c) | `` nixos/vellum: init module ``                                                                 |
| [`256268f3`](https://github.com/NixOS/nixpkgs/commit/256268f3fb92d26a35e8419b8ec5d571f625ef6a) | `` vellum: init at 0.6.0 ``                                                                     |
| [`45254f5c`](https://github.com/NixOS/nixpkgs/commit/45254f5c7415e0886f7779222df0a44db9af4f89) | `` gccNGPackages: Fix native build ``                                                           |
| [`830f73c6`](https://github.com/NixOS/nixpkgs/commit/830f73c651fca8973603bcaed2f87e6765c213e4) | `` gccNGPackages.gcc: Set --enable-host-* explicitly ``                                         |
| [`9f160d09`](https://github.com/NixOS/nixpkgs/commit/9f160d09877b6203da7a04528b014469441e1bd9) | `` lib.systems: build Cygwin with the split GCC package set ``                                  |
| [`6885c388`](https://github.com/NixOS/nixpkgs/commit/6885c388636c3c8f11b5ea4a8fcb56279a52d137) | `` gccNGPackages.libgcc: do not build shared for Cygwin ``                                      |
| [`199f517e`](https://github.com/NixOS/nixpkgs/commit/199f517ed4354086c937a6ceccfbae793439b1c8) | `` libbacktrace: Unbreak cygwin build ``                                                        |
| [`0ae00d7f`](https://github.com/NixOS/nixpkgs/commit/0ae00d7faeb4f5ae80cf7250c8510e018c9f9c0b) | `` gccNGPackages.libstdcxx-no-libc: Init for libcs written in C++ ``                            |
| [`85be8692`](https://github.com/NixOS/nixpkgs/commit/85be869221bcfe6487fa741f9c8d929a2f400913) | `` nixosTests.nginx-grpc-error-pages: init ``                                                   |
| [`833cd50e`](https://github.com/NixOS/nixpkgs/commit/833cd50ea66162533d3e70e9634d49a231a5a4b2) | `` nixos/nginx: add locations.<name>.useGrpcErrorPages option ``                                |
| [`403a0526`](https://github.com/NixOS/nixpkgs/commit/403a0526e1396425a1b7d4d0753767c6737cfffa) | `` nixos/frigate: use isolated /dev/shm for frame buffers ``                                    |
| [`a03f9611`](https://github.com/NixOS/nixpkgs/commit/a03f96113e538ff915f561f261328c2368faccaa) | `` arity: 0.18.0 -> 0.19.1 ``                                                                   |
| [`4fcb8b98`](https://github.com/NixOS/nixpkgs/commit/4fcb8b98afbe3dc689cf076c0042ad30ab38ffd1) | `` virter: 1.2.0 -> 1.2.1 ``                                                                    |
| [`dd672953`](https://github.com/NixOS/nixpkgs/commit/dd672953e2a4f763ef555aa95d3205d3ae904311) | `` yyjson: fix pkg-config paths ``                                                              |
| [`2110104f`](https://github.com/NixOS/nixpkgs/commit/2110104f31d2948dcc6f7cc8a3ae9cd296d287cc) | `` wasmer: 7.2.1 -> 7.3.0 ``                                                                    |
| [`96e2435e`](https://github.com/NixOS/nixpkgs/commit/96e2435e0553c8a94cd70a65992ee38ee2b51e32) | `` vulkanscenegraph: 1.1.15 -> 1.1.16 ``                                                        |
| [`7ac9c72f`](https://github.com/NixOS/nixpkgs/commit/7ac9c72fd40f336fa8fd12c696a773b998fe6ec9) | `` vscode-extensions.databricks.databricks: 2.13.0 -> 2.14.1 ``                                 |
| [`c4a25ad2`](https://github.com/NixOS/nixpkgs/commit/c4a25ad2884567e400dddf34cbf71c184f05c2ac) | `` python3Packages.fastexcel: 0.20.2 -> 0.21.0 ``                                               |
| [`355355e4`](https://github.com/NixOS/nixpkgs/commit/355355e4d9b07a4bfbe66af19b0dc4bd0e32ab1a) | `` terraform-providers.temporalio_temporalcloud: 1.6.0 -> 1.7.0 ``                              |
| [`0d8b0650`](https://github.com/NixOS/nixpkgs/commit/0d8b0650f84cc846e6c16c5f6b4179ba7995212e) | `` getopt: update homepage ``                                                                   |
| [`07970910`](https://github.com/NixOS/nixpkgs/commit/07970910a78426aba223182713197686357f471d) | `` getopt: set license ``                                                                       |
| [`5ede064d`](https://github.com/NixOS/nixpkgs/commit/5ede064d7a3ff1ffd7a3ad676cfe20b59f8ce211) | `` kubectl-gadget: 0.55.0 -> 0.55.1 ``                                                          |
| [`d1ac498b`](https://github.com/NixOS/nixpkgs/commit/d1ac498b2cdf63ea54beab0f77823bebc88ef45b) | `` tinyxxd: fix license ``                                                                      |
| [`d21fceea`](https://github.com/NixOS/nixpkgs/commit/d21fceea742c7bf366caa24b3b9ea0113bcf3534) | `` linuxPackages.amneziawg: fix stupid typo ``                                                  |
| [`eb454563`](https://github.com/NixOS/nixpkgs/commit/eb454563e9b310f22203e101f6f852210ca210c9) | `` zrythm: add mainProgram to meta attributes ``                                                |
| [`6d31c123`](https://github.com/NixOS/nixpkgs/commit/6d31c123d47c41b210e400e00b73c34290e76d9a) | `` teams-for-linux: Electron 41 -> 42 ``                                                        |
| [`6fb2ce33`](https://github.com/NixOS/nixpkgs/commit/6fb2ce33cef4402e4e1a93ba7812d3a56e4120bd) | `` intel-compute-runtime: 26.27.39122.11 -> 26.31.39395.13 ``                                   |
| [`95ea17c3`](https://github.com/NixOS/nixpkgs/commit/95ea17c3a4ba97953bd0d2f22b842282ed6e4cf3) | `` python3Packages.griffecli: inherit version and src from griffelib ``                         |
| [`f965dc43`](https://github.com/NixOS/nixpkgs/commit/f965dc431092ff21902d442275b289420f5cc705) | `` grafana: 13.1.3 -> 13.1.4, fix CVE-2026-17183 ``                                             |
| [`2ba148dc`](https://github.com/NixOS/nixpkgs/commit/2ba148dcc121c0195278832e5a055b737021f071) | `` python3Packages.asyncpraw: 8.0.2 -> 8.0.3 ``                                                 |
| [`204c0af5`](https://github.com/NixOS/nixpkgs/commit/204c0af5fb22366ec410bde3d9d8d9b121261ac5) | `` endless-sky: enable strictDeps & structuredAttrs ``                                          |
| [`efd5713c`](https://github.com/NixOS/nixpkgs/commit/efd5713cd58d087cc63cca966942e1280f864cdd) | `` home-assistant-custom-components.blueprints-updater: 2.12.2 -> 2.13.1 ``                     |
| [`d5a26f3c`](https://github.com/NixOS/nixpkgs/commit/d5a26f3c8362fc7a413b9bcdb50c8d6848d5fc6b) | `` python3Packages.vqgan-jax: drop ``                                                           |
| [`54e6bd26`](https://github.com/NixOS/nixpkgs/commit/54e6bd26321a7a7511e6f4674b1ca2a2a761fc24) | `` tree-sitter-grammars.tree-sitter-sourcepawn: 0.7.8 -> 0.8.0 ``                               |
| [`eb6553eb`](https://github.com/NixOS/nixpkgs/commit/eb6553ebff335597b6a5bf590f76011a98c19182) | `` vscode-extensions.danielsanmedium.dscodegpt: 3.24.43 -> 3.24.51 ``                           |
| [`09398a04`](https://github.com/NixOS/nixpkgs/commit/09398a04c2f4d57814a94c8a6eb7414d123bf0c5) | `` tirith: 0.3.1 -> 0.3.3 ``                                                                    |
| [`35beee13`](https://github.com/NixOS/nixpkgs/commit/35beee13368553c1621089d645186ac53d34afce) | `` ultrastardx: 2026.8.0 -> 2026.8.1 ``                                                         |
| [`99140549`](https://github.com/NixOS/nixpkgs/commit/99140549922238962bad0e6b31b28be4454976c1) | `` nixos/tests/fcitx5: use boolean literals ``                                                  |
| [`a464eca8`](https://github.com/NixOS/nixpkgs/commit/a464eca85b76c8a7a8bfab51a943a1dd4ef8523b) | `` matrix-synapse: 1.158.0 -> 1.159.0 ``                                                        |
| [`6a8a936d`](https://github.com/NixOS/nixpkgs/commit/6a8a936dbfd0dbec91ba4a01d4d9e9875b6dad15) | `` python3Packages.matrix-nio: fix encryption support ``                                        |
| [`a1dcafc6`](https://github.com/NixOS/nixpkgs/commit/a1dcafc68340171a379c23bad83909bc6e6d0a9b) | `` nixos/fcitx: fix usage of boolean for settings ``                                            |
| [`dbf59c71`](https://github.com/NixOS/nixpkgs/commit/dbf59c71c1b439b117f0c1e3877ac2d203f7052b) | `` libretro-shaders-slang: 0-unstable-2026-08-08 -> 0-unstable-2026-08-20 ``                    |
| [`6d294837`](https://github.com/NixOS/nixpkgs/commit/6d294837267246eb20b6a6638870d321d30cb7fb) | `` librewolf-bin-unwrapped: 153.0.4-1 -> 154.0-2 ``                                             |
| [`c4fc2333`](https://github.com/NixOS/nixpkgs/commit/c4fc2333e83988721a9c3cfa0bbbe3772ff0e91a) | `` libretro.snes9x: 0-unstable-2026-08-09 -> 0-unstable-2026-08-17 ``                           |
| [`ee7c321d`](https://github.com/NixOS/nixpkgs/commit/ee7c321d12eec70e619b9f46aaba1c6f355da402) | `` coldsnap: 0.11.0 -> 0.12.0 ``                                                                |
| [`99aad472`](https://github.com/NixOS/nixpkgs/commit/99aad4726b16d5f46f5bafb1adc8c8ef95b39d2e) | `` python3Packages.vodozemac: init at 0.10.0 ``                                                 |
| [`731e1ae9`](https://github.com/NixOS/nixpkgs/commit/731e1ae9144ee7d89250368092bc5fb49db80824) | `` maintainers: remove steeleduncan ``                                                          |
| [`2ee0d3d5`](https://github.com/NixOS/nixpkgs/commit/2ee0d3d5eb7c9566c5610c8a03d73ca38f753942) | `` microhs: remove steeleduncan as maintainer ``                                                |
| [`cadcd60e`](https://github.com/NixOS/nixpkgs/commit/cadcd60ee4f5fd1a66072eea63f42cb02d38c6d8) | `` objfw: remove steeleduncan as maintainer ``                                                  |
| [`e13ead53`](https://github.com/NixOS/nixpkgs/commit/e13ead53334bb0d0a3e1912c0612e03e21a9769d) | `` centrifugo: 6.9.1 -> 6.9.2 ``                                                                |
| [`5b683b87`](https://github.com/NixOS/nixpkgs/commit/5b683b87249e1b5eb68062fdff2d50358a85a9e5) | `` python3Packages.databricks-sdk: 0.127.0 -> 0.133.0 ``                                        |
| [`7a01b6dd`](https://github.com/NixOS/nixpkgs/commit/7a01b6dd57075c82e12cf42f04350f4cf5c4221e) | `` matrix-authentication-service: 1.22.0 -> 1.23.0 ``                                           |
| [`480b0208`](https://github.com/NixOS/nixpkgs/commit/480b0208dcd609cbaf794260e824e72493c19d25) | `` noctalia: ensure canExecute when installing shell completions ``                             |
| [`4f142abb`](https://github.com/NixOS/nixpkgs/commit/4f142abbd1fd3f0271743baf2b0a8b14f7d8cb36) | `` dita-ot: 4.4 -> 4.4.1 ``                                                                     |
| [`6f02cb73`](https://github.com/NixOS/nixpkgs/commit/6f02cb73f49abbeb173f2acb30b61d24071402df) | `` containerlab: 0.78.0 -> 0.78.2 ``                                                            |
| [`a3abf306`](https://github.com/NixOS/nixpkgs/commit/a3abf3062a2b904415c2ccba1bf361e3f4a919c1) | `` drawio: 31.1.8 -> 31.3.1 ``                                                                  |
| [`3f125129`](https://github.com/NixOS/nixpkgs/commit/3f12512924b7d7824ee576b706c0af17af31adbe) | `` feishu-cli: 1.38.3 -> 1.39.0 ``                                                              |
| [`5558195c`](https://github.com/NixOS/nixpkgs/commit/5558195cce0e8ad9061ff12e40b8e4797eb16704) | `` bisq1: 1.10.4 -> 1.10.5 ``                                                                   |
| [`c022cedf`](https://github.com/NixOS/nixpkgs/commit/c022cedf343226cc8a020103ba91939573e5b5b3) | `` luanti: 5.16.1 -> 5.17.0 ``                                                                  |
| [`3af88017`](https://github.com/NixOS/nixpkgs/commit/3af88017de31f78c9a31ca3a5e19f9a26c857afc) | `` udpipe1: init at version 1.4.0 ``                                                            |
| [`f91f92f7`](https://github.com/NixOS/nixpkgs/commit/f91f92f75bb38dd03d214cd24fdbcb4f6703fbd3) | `` .github: Bump cachix/install-nix-action from 31.11.0 to 31.11.1 ``                           |
| [`217509c9`](https://github.com/NixOS/nixpkgs/commit/217509c936ae32499f1cca4821198d79b63cd703) | `` troubadix: 26.8.1 -> 26.8.2 ``                                                               |
| [`1a8f6888`](https://github.com/NixOS/nixpkgs/commit/1a8f6888c85b90fc521fd1dc1c3b64b933b055f3) | `` stackit-cli: 0.70.0 -> 0.71.0 ``                                                             |
| [`98c4a9b1`](https://github.com/NixOS/nixpkgs/commit/98c4a9b1b5b59045d9edb681fb5973a233f145b1) | `` python3Packages.zhong-hong-hvac: 1.0.18 -> 1.0.19 ``                                         |
| [`d5698bf3`](https://github.com/NixOS/nixpkgs/commit/d5698bf32dc74c99e65b7c695d4c5ccdbca4e4df) | `` nixos.acme: fix option descriptions ``                                                       |
| [`2a04ab20`](https://github.com/NixOS/nixpkgs/commit/2a04ab204840c165ca74a8de5e6a80d83a6924da) | `` mk-kde-derivation: make use of `lib.licensesSpdx` instead of a custom map ``                 |
| [`0af8aa4f`](https://github.com/NixOS/nixpkgs/commit/0af8aa4f3104e5125f816b44d3503c2b2aa83c69) | `` python3Packages.modelscope: 1.39.0 -> 1.39.1 ``                                              |
| [`47ce4f13`](https://github.com/NixOS/nixpkgs/commit/47ce4f13f7943a0db5b9011a1b4cac77fa5c00d1) | `` afetch: added strictDeps, __structuredAttrs, and enableParallelBuilding ``                   |
| [`5bd22d91`](https://github.com/NixOS/nixpkgs/commit/5bd22d912ee6974f8194271f5aa4120df1eca156) | `` mistral-rs: 0.9.1 -> 0.9.2 ``                                                                |
| [`037d0c0b`](https://github.com/NixOS/nixpkgs/commit/037d0c0b6a5e76efdaa2dad769c08e213f848029) | `` _9base: use __structuredAttrs ``                                                             |
| [`7b4cb14f`](https://github.com/NixOS/nixpkgs/commit/7b4cb14ff81fd21ecf56d5b000e42db9240ea960) | `` python3Packages.skia-pathops: add wegank as maintainer ``                                    |
| [`374555fd`](https://github.com/NixOS/nixpkgs/commit/374555fd645f2472b5ee3ec07081edd35c13ee51) | `` nixos/containers: fixup 21e032ff9522 ``                                                      |
| [`86e75d89`](https://github.com/NixOS/nixpkgs/commit/86e75d89038f27350d85f7fe11f1985142b754b5) | `` chromium,chromedriver: 151.0.7922.169 -> 151.0.7922.173 ``                                   |
| [`375ba8cc`](https://github.com/NixOS/nixpkgs/commit/375ba8cc1565de35d6faf20ba0c2b30388f7092d) | `` warmup-s3-archives: 1.2.2 -> 1.3.0 ``                                                        |
| [`4aa9218c`](https://github.com/NixOS/nixpkgs/commit/4aa9218c9481c80d5980b555c0a5cbd78932f980) | `` lucida-downloader: 0.8.0 -> 0.9.0 ``                                                         |
| [`e504856f`](https://github.com/NixOS/nixpkgs/commit/e504856fa4ff91f59f982e70bf7a2ed1e6882b3f) | `` skyscraper: 3.20.3 -> 3.20.4 ``                                                              |
| [`6c367f81`](https://github.com/NixOS/nixpkgs/commit/6c367f8160a94e36064792ea2a2cabd905c1856d) | `` beekeeper-studio: 6.0.0 -> 6.0.4 ``                                                          |
| [`efcb8cc9`](https://github.com/NixOS/nixpkgs/commit/efcb8cc970db51ee531e1f83d75cce02dc94456e) | `` seaweedfs: 4.42 -> 4.43 ``                                                                   |
| [`f0db8ef8`](https://github.com/NixOS/nixpkgs/commit/f0db8ef82c2f8cfcf04303cfb3b83a0bfb712531) | `` inputplumber: 0.78.0 -> 0.78.1 ``                                                            |
| [`b32d89fc`](https://github.com/NixOS/nixpkgs/commit/b32d89fccac63aedd569d4b4b6f173ab4cfac001) | `` python3Packages.parsedmarc: migrate to finalAtrrs ``                                         |
| [`b86e4990`](https://github.com/NixOS/nixpkgs/commit/b86e4990e97a170367349914230b6f3068cd3c9b) | `` python3Packages.parsedmarc: 10.2.0 -> 10.4.3 ``                                              |
| [`5d6f4b74`](https://github.com/NixOS/nixpkgs/commit/5d6f4b7405476d09f10cc46f87694cd76e4e88f9) | `` python3Packages.mailsuite: 2.2.2 -> 2.3.1 ``                                                 |
| [`01ea912f`](https://github.com/NixOS/nixpkgs/commit/01ea912f17ddd9f46d8695b3f4fead7b7f5b50e9) | `` prowler: 5.39.0 -> 5.39.1 ``                                                                 |
| [`fa3529cd`](https://github.com/NixOS/nixpkgs/commit/fa3529cdc045ae7732803d7e440fbce3c1d2c231) | `` rerun: 0.36.0 -> 0.36.1 ``                                                                   |
| [`827c369c`](https://github.com/NixOS/nixpkgs/commit/827c369c6432229c3683d562b67bfb95a95b0fa0) | `` python3Packages.pyluwen: 0.8.5 -> 0.9.0 ``                                                   |
| [`7954dcf5`](https://github.com/NixOS/nixpkgs/commit/7954dcf569a568caef0ef1bc3e655c29f3b4f638) | `` teams-for-linux: 2.15.0 -> 2.17.1 ``                                                         |
| [`7fe5ff26`](https://github.com/NixOS/nixpkgs/commit/7fe5ff26fc1733d7aec82df85260ab0cc5625638) | `` python3Packages.holidays: 0.102 -> 0.103 ``                                                  |
| [`f4667a19`](https://github.com/NixOS/nixpkgs/commit/f4667a19fc46e97ecaf58c06f3c86ff03ecf2cf4) | `` python3Packages.yoto-api: 4.3.2 -> 4.3.4 ``                                                  |
| [`fcd3e013`](https://github.com/NixOS/nixpkgs/commit/fcd3e013c6ef5d767332a0fbf2249d2c6fe76456) | `` python3Packages.garminconnect: 0.3.10 -> 0.3.11 ``                                           |
| [`62bfc0a7`](https://github.com/NixOS/nixpkgs/commit/62bfc0a7535b7941dcdc342f818b87d1da9cad20) | `` mistral-vibe: 2.24.0 -> 2.24.2 ``                                                            |
| [`5b1a630c`](https://github.com/NixOS/nixpkgs/commit/5b1a630cf55841d7a78cfaba6b33179d2d5b461c) | `` python3Packages.claude-agent-sdk: 0.2.141 -> 0.2.143 ``                                      |
| [`f2d6cf4f`](https://github.com/NixOS/nixpkgs/commit/f2d6cf4ffc988fbdb5d3e25c1e7752a2b7360469) | `` python3Packages.claude-agent-sdk: 0.2.140 -> 0.2.141 ``                                      |
| [`1afc63d2`](https://github.com/NixOS/nixpkgs/commit/1afc63d20fa56f2c7f7928205c173a3b3768419f) | `` python3Packages.agentic-threat-hunting-framework: 0.18.0 -> 0.19.0 ``                        |
| [`a2f094aa`](https://github.com/NixOS/nixpkgs/commit/a2f094aac72662635fb92f212d03c2a74974e826) | `` python3Packages.alibabacloud-cs20151215: 7.1.0 -> 7.1.1 ``                                   |
| [`a400ea70`](https://github.com/NixOS/nixpkgs/commit/a400ea7097b1a2724e30a42ba46a785cd2624498) | `` python3Packages.publicsuffixlist: 1.0.2.20260819 -> 1.0.2.20260821 ``                        |
| [`d6255f6b`](https://github.com/NixOS/nixpkgs/commit/d6255f6b034e10938fa611f293301e8707486e41) | `` python3Packages.tencentcloud-sdk-python: 3.1.161 -> 3.1.162 ``                               |
| [`a21755c5`](https://github.com/NixOS/nixpkgs/commit/a21755c57f7564f76c8470a32fe5e063408003d9) | `` python3Packages.iamdata: 0.1.202608201 -> 0.1.202608211 ``                                   |
| [`dbb93679`](https://github.com/NixOS/nixpkgs/commit/dbb936791d29f12229e682290a9490e7879f2e09) | `` namespace-cli: 0.0.556 -> 0.0.557 ``                                                         |
| [`5335193b`](https://github.com/NixOS/nixpkgs/commit/5335193bbf30cd7894013d1b9635fc35427cc713) | `` fairywren: 0-unstable-2026-07-21 -> 0-unstable-2026-08-21 ``                                 |
| [`214c9f4c`](https://github.com/NixOS/nixpkgs/commit/214c9f4c1250fedbec38fde5034fc64a72cf21fe) | `` python3Packages.pyrisco: 0.8.0 -> 0.8.1 ``                                                   |
| [`b2b146ec`](https://github.com/NixOS/nixpkgs/commit/b2b146ec437375820292dd50d2fff1f4037b99ea) | `` tuigreet: 0.11.0 -> 0.11.1 ``                                                                |
| [`d0fbd3e3`](https://github.com/NixOS/nixpkgs/commit/d0fbd3e365f1ef28adf7b9185fda909c33164273) | `` renovate: 44.24.3 -> 44.37.1 ``                                                              |
| [`274e939f`](https://github.com/NixOS/nixpkgs/commit/274e939ff62bc22c530040bf99e818ccd7a0214a) | `` python3Packages.torchvision-bin: 0.27.0 -> 0.27.1 ``                                         |
| [`ed241593`](https://github.com/NixOS/nixpkgs/commit/ed241593084eea1ff18c497f772f250a00e44fe5) | `` python3Packages.torch-bin: 2.12.0 -> 2.12.1 ``                                               |
| [`4dd4b3d1`](https://github.com/NixOS/nixpkgs/commit/4dd4b3d145487a50b92fd6eafd0cc66d6fd19a8d) | `` python3Packages.triton-bin: 3.7.0 -> 3.7.1 ``                                                |
| [`2fe062a5`](https://github.com/NixOS/nixpkgs/commit/2fe062a57546d099d35e362a7d3ea44e52ec9059) | `` scdl: 3.0.7 -> 3.0.8 ``                                                                      |
| [`5fd3c806`](https://github.com/NixOS/nixpkgs/commit/5fd3c8068841ab11281b494521dd530a81cc0ad2) | `` tuicr: 0.23.0 -> 0.23.1 ``                                                                   |
| [`f9140164`](https://github.com/NixOS/nixpkgs/commit/f9140164d65613e89d83a958fad2490db5a6b26f) | `` piped: 0-unstable-2026-08-09 -> 0-unstable-2026-08-13 ``                                     |
| [`2cd094f4`](https://github.com/NixOS/nixpkgs/commit/2cd094f44e2d6338e45fafefc939b19e1503a4e6) | `` lib.licenses: mark `vol-sl` as unfree ``                                                     |
| [`c10138b0`](https://github.com/NixOS/nixpkgs/commit/c10138b066e9a0faa34d82760bd05abf1423a6c5) | `` Revert "syncstorage-rs: set updatescript if dbBackend == mysql" ``                           |
| [`5cc4a631`](https://github.com/NixOS/nixpkgs/commit/5cc4a631df353ef9202cff3076813e1d5a243e28) | `` vscode-extensions.anthropic.claude-code: 2.1.237 -> 2.1.238 ``                               |
| [`6d5d7cba`](https://github.com/NixOS/nixpkgs/commit/6d5d7cbac5ab87dc27d997dbe2fc441eb97246f8) | `` claude-code: 2.1.237 -> 2.1.238 ``                                                           |
| [`dd6c2503`](https://github.com/NixOS/nixpkgs/commit/dd6c2503a06d0cf64811dfda75cd4a69b558bf64) | `` xload: 1.2.1 -> 1.2.2 ``                                                                     |
| [`67fb3df2`](https://github.com/NixOS/nixpkgs/commit/67fb3df2e28a15aeb68a7ae99eccf215549897c4) | `` mailmap: add github noreply email to ethancedwards8 entry ``                                 |
| [`d3c51f9e`](https://github.com/NixOS/nixpkgs/commit/d3c51f9e720e687fa84087a320cb992a38b340c3) | `` python3Packages.oelint-data: 1.5.14 -> 1.5.16 ``                                             |
| [`b20708d7`](https://github.com/NixOS/nixpkgs/commit/b20708d7dbefae4e6a6d3c55b4229b21fb6d0069) | `` mongodb-tools: 100.17.0 -> 100.18.0 ``                                                       |
| [`b23806ad`](https://github.com/NixOS/nixpkgs/commit/b23806ad8f4dd4e6be08305d5f850cb0dc83d618) | `` vscode-extensions.banacorn.agda-mode: 0.10.0 -> 0.10.1 ``                                    |
| [`cc1b7d79`](https://github.com/NixOS/nixpkgs/commit/cc1b7d790a6ad6ea4d431d112871bca5716e5c63) | `` maintainers/github-teams.json: Automated sync ``                                             |
| [`49f3caae`](https://github.com/NixOS/nixpkgs/commit/49f3caaecd683bee1872d0a0148d65cfe5111689) | `` python3Packages.pcffont: 0.0.25 -> 0.0.33 ``                                                 |
| [`40d6e20c`](https://github.com/NixOS/nixpkgs/commit/40d6e20c1560ec17f10064ce0f45c02c6e161c98) | `` wiki-go: 1.8.12 -> 1.8.13 ``                                                                 |
| [`48aeb705`](https://github.com/NixOS/nixpkgs/commit/48aeb70597daff5c55ce8e78a8cc95dba8c8f9e4) | `` automatic-timezoned: modernize ``                                                            |
| [`5637515f`](https://github.com/NixOS/nixpkgs/commit/5637515fea143a751f10e3034f7c1f1ea67a768d) | `` signalbackup-tools: 20260718 -> 20260820 ``                                                  |
| [`8ac14c2a`](https://github.com/NixOS/nixpkgs/commit/8ac14c2a3ab1b022bab731943cdd83c16222b78a) | `` serie: 0.8.1 -> 0.8.2 ``                                                                     |
| [`67b0f51e`](https://github.com/NixOS/nixpkgs/commit/67b0f51eb52c405049af8b26d265a70f67c77d41) | `` pappl: 1.4.11 -> 1.4.12 ``                                                                   |
| [`dbe5eb31`](https://github.com/NixOS/nixpkgs/commit/dbe5eb313100019fe21cda54d5e7fc4470bead2d) | `` klipper-flash: match flashUsbSupportedBoards by prefix, not exact value ``                   |
| [`6eadd126`](https://github.com/NixOS/nixpkgs/commit/6eadd126bb3b68fa5a607b9d4dfe335ac7e290dc) | `` randomx: 1.2.2 -> 1.2.3 ``                                                                   |
| [`320039ae`](https://github.com/NixOS/nixpkgs/commit/320039ae3a02aca9c1d04e56732f2503be87ea72) | `` python3Packages.mhcgnomes: 3.33.4 -> 3.33.5 ``                                               |
| [`1c8898dd`](https://github.com/NixOS/nixpkgs/commit/1c8898ddf786b677418807a21e10f0b828169b79) | `` python3Packages.asyncpraw: enable structuredAttrs ``                                         |
| [`7840845d`](https://github.com/NixOS/nixpkgs/commit/7840845d4228b0431f1c21df4b1e21a6d92d6ff7) | `` aws-cdk-cli: 2.1135.0 -> 2.1138.0 ``                                                         |
| [`d79033fb`](https://github.com/NixOS/nixpkgs/commit/d79033fb0b1d9d1bef3dfdfdc0f570120072b04d) | `` bottom: 0.14.7 -> 0.14.8 ``                                                                  |
| [`6776cca3`](https://github.com/NixOS/nixpkgs/commit/6776cca38c370326f7da3132c43ae0b0eedb4f47) | `` music-assistant-desktop: add gst_all_1 ``                                                    |
| [`c17fa36f`](https://github.com/NixOS/nixpkgs/commit/c17fa36f2de69f4d9e0c8ec68f6440950b496b78) | `` python3Packages.pyimouapi: 1.3.4 -> 1.3.5 ``                                                 |
| [`883d2e1c`](https://github.com/NixOS/nixpkgs/commit/883d2e1c51b2f7daccab433dd6f6ad326707933b) | `` automatic-timezoned: 2.0.153 -> 2.0.156 ``                                                   |
| [`1fdd467b`](https://github.com/NixOS/nixpkgs/commit/1fdd467b8d33edaebc08d86efdfc62c09215f172) | `` gh: 2.97.0 -> 2.98.0 ``                                                                      |
| [`5dbe94e9`](https://github.com/NixOS/nixpkgs/commit/5dbe94e9391d6a15cf7485da129c0596ba34d339) | `` testkube: modernize ``                                                                       |
| [`282e2b5f`](https://github.com/NixOS/nixpkgs/commit/282e2b5f55e2cc248599fbc2870811a26ac6810c) | `` ansifilter: 2.22 -> 2.23 ``                                                                  |
| [`aebfabf5`](https://github.com/NixOS/nixpkgs/commit/aebfabf544f76588c64a1fa30ec4d9178ea3d181) | `` libretro.dolphin: 0-unstable-2026-08-02 -> 0-unstable-2026-08-19 ``                          |
| [`cae447da`](https://github.com/NixOS/nixpkgs/commit/cae447dac6edd69ceea6e2f10bbcbefe78a9e194) | `` romm: 5.1.0 -> 5.2.0 ``                                                                      |
| [`dd420850`](https://github.com/NixOS/nixpkgs/commit/dd4208504805aa9ac503c6cb5fa879fafeebac6d) | `` python3Packages.google-health-api: 0.8.0 -> 0.10.0 ``                                        |
| [`98e164f1`](https://github.com/NixOS/nixpkgs/commit/98e164f1593492287a2b33317bf1a5d6f72771e5) | `` ffmpeg: fix loongarch64-linux build ``                                                       |
| [`23b19c14`](https://github.com/NixOS/nixpkgs/commit/23b19c14f5e49872d74a3b487960beee7cf5866c) | `` libretro.picodrive: 0-unstable-2026-07-29 -> 0-unstable-2026-08-20 ``                        |
| [`5a980284`](https://github.com/NixOS/nixpkgs/commit/5a9802846aa39536db0b6ec73f8545a439785525) | `` ctx: fix eval on unsupported systems ``                                                      |
| [`4d11c1b8`](https://github.com/NixOS/nixpkgs/commit/4d11c1b83e68afcb58e0f37ac0471d760543f00f) | `` rustnet: 1.5.0 -> 1.6.0 ``                                                                   |
| [`c1c78d0d`](https://github.com/NixOS/nixpkgs/commit/c1c78d0dd5f2de3b352a55b06ff53a36524159f0) | `` lukesmithxyz-bible-kjv: Fix invalid unstable version scheme ``                               |
| [`24e99e08`](https://github.com/NixOS/nixpkgs/commit/24e99e08919297fe5ad2fd8ab96e983d8006f9d9) | `` radicle-node: fix failing test, add strictDeps and stricturedAttrs ``                        |
| [`bcfbc66b`](https://github.com/NixOS/nixpkgs/commit/bcfbc66b6c48c685fce3f98222bc633d4b3af03a) | `` radicle-node-unstable: move out of top-level, fix unstable updater script ``                 |
| [`2ed0c971`](https://github.com/NixOS/nixpkgs/commit/2ed0c971f831454871c60dfdef05ba188e33c121) | `` xhosts: Fix invalid unstable version scheme ``                                               |
| [`c8872966`](https://github.com/NixOS/nixpkgs/commit/c8872966eb35838c2165dd72a90673071caeca26) | `` grafanaPlugins.grafana-lokiexplore-app: 2.5.0 -> 2.5.1 ``                                    |
| [`bc9c12f1`](https://github.com/NixOS/nixpkgs/commit/bc9c12f1de74fe264623bcd251968c6455214c20) | `` pwneye: init at 1.3.2 ``                                                                     |
| [`e0ad45d4`](https://github.com/NixOS/nixpkgs/commit/e0ad45d45a15cecb325676c501a2a9e4b7a3a943) | `` temurin-bin: fix eval on unsupported systems ``                                              |
| [`5d219d4e`](https://github.com/NixOS/nixpkgs/commit/5d219d4e838987743aec78b674ab52acd73f180c) | `` python3Packages.onvif-python: init at 0.2.10 ``                                              |
| [`6770c304`](https://github.com/NixOS/nixpkgs/commit/6770c3044f01cfa053f511770a65bdfb876f980b) | `` changie: 1.25.2 -> 1.26.0 ``                                                                 |
| [`e5a61c87`](https://github.com/NixOS/nixpkgs/commit/e5a61c87299414ded8643aa37105af0a4065cafa) | `` dolibarr: 23.0.3 -> 24.0.0 ``                                                                |
| [`e8803912`](https://github.com/NixOS/nixpkgs/commit/e8803912da743d1a73032d7976f9a8ae6cce0076) | `` python3Packages.stripe: 15.5.0 -> 15.5.1 ``                                                  |
| [`3889bc84`](https://github.com/NixOS/nixpkgs/commit/3889bc84ab7d6da971cfdf5027a448d8c3c68460) | `` python3Packages.pyportainer: 1.0.43 -> 1.0.44 ``                                             |
| [`e37d5b48`](https://github.com/NixOS/nixpkgs/commit/e37d5b48928fb8bcc23dfd42b227d83ad9135856) | `` osinfo-db: 20251212 -> 20260812 ``                                                           |
| [`300ae5fe`](https://github.com/NixOS/nixpkgs/commit/300ae5fe2eb3af7830bac0b4a40b67773ede204f) | `` python3Packages.py-key-value-shared-test: remove ``                                          |
| [`412153e5`](https://github.com/NixOS/nixpkgs/commit/412153e51373a9420d808e5e18f2fec42d393fe2) | `` python3Packages.py-key-value-shared: remove ``                                               |
| [`f5a2ae07`](https://github.com/NixOS/nixpkgs/commit/f5a2ae073c73291e11e194aa060bad164a0d6403) | `` python3Packages.py-key-value-aio: 0.3.0 -> 0.4.5 ``                                          |
| [`468860e0`](https://github.com/NixOS/nixpkgs/commit/468860e0b0de9f1f91dab3d2997aae5a4bea7ebc) | `` python3Packages.aiofile: 3.8.6 -> 3.12.3 ``                                                  |
| [`e0352cb7`](https://github.com/NixOS/nixpkgs/commit/e0352cb77dffb74b59d4cfc8019acc6b1417f3a2) | `` home-assistant-custom-lovelace-modules.flower-card: 2026.7.0 -> 2026.8.0 ``                  |
| [`2fda0964`](https://github.com/NixOS/nixpkgs/commit/2fda09649f06f680627da65ccad1113e7fb65bfc) | `` curl-impersonate: fix cross compilation ``                                                   |
| [`54f9777a`](https://github.com/NixOS/nixpkgs/commit/54f9777a04bf8792677f3a9f4a9e21eb0e8766d7) | `` python3Packages.caio: 0.10.1 -> 0.12.3 ``                                                    |
| [`fdf9f937`](https://github.com/NixOS/nixpkgs/commit/fdf9f937739d762c2b03a6029bf781fd9fd33d79) | `` python3Packages.numpyro: fix build ``                                                        |
| [`edbdbfbd`](https://github.com/NixOS/nixpkgs/commit/edbdbfbd5c6604a02e90b0b09d1a16fc9f456e92) | `` python3Packages.equinox: make pytest ignore UserWarning ``                                   |
| [`47ca21b2`](https://github.com/NixOS/nixpkgs/commit/47ca21b22dbadd6c7c79f9bd64c2eb16839e3cd5) | `` python3Packages.flax: 0.12.8 -> 0.12.9 ``                                                    |
| [`a5f39a5c`](https://github.com/NixOS/nixpkgs/commit/a5f39a5c9bc13feec016aa4efe4218d0eb970e32) | `` python3Packages.blackjax: skip failing test ``                                               |
| [`5ce441bd`](https://github.com/NixOS/nixpkgs/commit/5ce441bd1b431d57aed03c894e3761a6221cca0b) | `` python3Packages.jmp: cleanup, fix ``                                                         |
| [`24d2dcc6`](https://github.com/NixOS/nixpkgs/commit/24d2dcc622d43d24f84ef0f2536f50bf1fce0fb8) | `` libzim: 9.8.1 -> 9.8.2 ``                                                                    |
| [`7cb40ee8`](https://github.com/NixOS/nixpkgs/commit/7cb40ee81868af3f42665281a1f1b4d42433c25a) | `` turbovnc: Drop "beta" from links (those don't exist as beta) ``                              |
| [`740b19db`](https://github.com/NixOS/nixpkgs/commit/740b19db0bb9dd189cd0f6587c34144063c5affd) | `` noctalia: install shell completions ``                                                       |
| [`15746dad`](https://github.com/NixOS/nixpkgs/commit/15746dadb97cea422b20dda9910c304aad736de2) | `` oauth2l: 1.3.4 -> 1.3.5 ``                                                                   |
| [`72d29f03`](https://github.com/NixOS/nixpkgs/commit/72d29f0317a5fc49b303ddd18dd54eb0043e0961) | `` google-chrome: 151.0.7922.169 -> 151.0.7922.173 ``                                           |
| [`2801f03a`](https://github.com/NixOS/nixpkgs/commit/2801f03ac6b1318d58dc655baf81e6c8f375c3cf) | `` python3Packages.great-tables: turn unused-snapshot error into warning ``                     |
| [`450965b2`](https://github.com/NixOS/nixpkgs/commit/450965b20d9eceba00cb6ac6c6db6da2256effe5) | `` crc: 2.62.0 -> 2.63.0 ``                                                                     |
| [`6fb8798f`](https://github.com/NixOS/nixpkgs/commit/6fb8798fe05b321632bd19568b00d153e176be4e) | `` terraform-providers.hashicorp_time: 0.14.0 -> 0.14.1 ``                                      |
| [`fb81a61c`](https://github.com/NixOS/nixpkgs/commit/fb81a61c8576a573708c359a68e3bf5515812758) | `` cudatext: 1.235.1.0 -> 1.236.0.3 ``                                                          |
| [`6195b57d`](https://github.com/NixOS/nixpkgs/commit/6195b57d6a3af4e604862f6428d98467cadc8011) | `` atlantis: 0.47.0 -> 0.47.1 ``                                                                |
| [`4a06ae4e`](https://github.com/NixOS/nixpkgs/commit/4a06ae4ee36f46ae75225671c8b2135e8eaffdfc) | `` luaPackages.kulala-nvim: 6.28.0-1 -> 6.29.0-1 ``                                             |
| [`82a445e2`](https://github.com/NixOS/nixpkgs/commit/82a445e204050b93cc295beda66a241f1c2934f0) | `` terraform-providers.aliyun_alicloud: 1.288.0 -> 1.289.0 ``                                   |
| [`252b1388`](https://github.com/NixOS/nixpkgs/commit/252b13888b585515a8efce9127fd839c2c3f5c79) | `` dart-sass: 1.102.0 -> 1.103.0 ``                                                             |
| [`38866d52`](https://github.com/NixOS/nixpkgs/commit/38866d5238b0a8519f56fdb5f9fb3f8cac46a524) | `` python3Packages.boto3-stubs: 1.43.74 -> 1.43.76 ``                                           |
| [`4d0d222d`](https://github.com/NixOS/nixpkgs/commit/4d0d222d00048269e4b61268bd34a334e5fcd7e2) | `` python3Packages.mypy-boto3-vpc-lattice: 1.43.37 -> 1.43.75 ``                                |
| [`4f729ff6`](https://github.com/NixOS/nixpkgs/commit/4f729ff6a65fdc7ec85d0661dd4eacdbc695fc0e) | `` python3Packages.mypy-boto3-sesv2: 1.43.54 -> 1.43.76 ``                                      |
| [`fbc11ce2`](https://github.com/NixOS/nixpkgs/commit/fbc11ce2f9a332a28449e8444d2b3618c3397ced) | `` python3Packages.mypy-boto3-sagemaker: 1.43.72 -> 1.43.76 ``                                  |
| [`a21104fb`](https://github.com/NixOS/nixpkgs/commit/a21104fb6fa0b5313e5a9dd4154ded84187bcd67) | `` python3Packages.mypy-boto3-redshift-serverless: 1.43.72 -> 1.43.75 ``                        |
| [`c0495e77`](https://github.com/NixOS/nixpkgs/commit/c0495e77683e624c808f7738cd6d9803139c2ed9) | `` python3Packages.mypy-boto3-redshift: 1.43.72 -> 1.43.75 ``                                   |
| [`7e468c2f`](https://github.com/NixOS/nixpkgs/commit/7e468c2f38c807a37f73d45051d15552b0e9cffd) | `` ungoogled-chromium: 151.0.7922.137-1 -> 151.0.7922.169-1 ``                                  |
| [`5d7a52a1`](https://github.com/NixOS/nixpkgs/commit/5d7a52a14448d1102eccc4ecdc2c433ee36274b7) | `` python3Packages.mypy-boto3-medialive: 1.43.74 -> 1.43.75 ``                                  |
| [`0c3cdada`](https://github.com/NixOS/nixpkgs/commit/0c3cdada45db0e971c58ba263521f97dd340fdc7) | `` scopehal-apps: 0.1.1 -> 0.2.2 ``                                                             |
| [`1a882794`](https://github.com/NixOS/nixpkgs/commit/1a8827941ab5b793c817d3d4c93182bc41fb9c5f) | `` python3Packages.mypy-boto3-lambda: 1.43.60 -> 1.43.76 ``                                     |
| [`ad14738e`](https://github.com/NixOS/nixpkgs/commit/ad14738ea991123adf08ca97f98e526d6f4ed2a4) | `` python3Packages.mypy-boto3-eks: 1.43.69 -> 1.43.75 ``                                        |
| [`f8fb6aa7`](https://github.com/NixOS/nixpkgs/commit/f8fb6aa784c1cae690729ac7c398f85bfd32a046) | `` python3Packages.mypy-boto3-ec2: 1.43.74 -> 1.43.76 ``                                        |
| [`a918566f`](https://github.com/NixOS/nixpkgs/commit/a918566f92673f8bcb052052eb75d8ce2b91eae3) | `` python3Packages.mypy-boto3-directconnect: 1.43.63 -> 1.43.76 ``                              |
| [`55355a23`](https://github.com/NixOS/nixpkgs/commit/55355a23431b03f2a0e1aa4dc552bdb12fb13b67) | `` fosrl-newt: 1.15.0 -> 1.16.0 ``                                                              |
| [`115fe6a3`](https://github.com/NixOS/nixpkgs/commit/115fe6a3d54eb979d9fa1c71c856576c2f001a9d) | `` ersatztv: 26.7.1 -> 26.8.0 ``                                                                |
| [`c1d46f1e`](https://github.com/NixOS/nixpkgs/commit/c1d46f1e1ee6222f9988bf3cb6f31b4832948dde) | `` python3Packages.mypy-boto3-cloudfront: 1.43.8 -> 1.43.76 ``                                  |
| [`590c04c1`](https://github.com/NixOS/nixpkgs/commit/590c04c1219fd09696556cb87e7222b8d38707e3) | `` dotnetCorePackages.sdk_11_0: 11.0.100-preview.6.26359.118 -> 11.0.100-preview.7.26381.103 `` |
| [`4862a919`](https://github.com/NixOS/nixpkgs/commit/4862a919017b040f59d1adb4c67840efee8092cf) | `` dotnetCorePackages.sdk_10_0: 10.0.302 -> 10.0.400 ``                                         |
| [`feb182c7`](https://github.com/NixOS/nixpkgs/commit/feb182c72288a27342f31a6dd97ffc1ef59d7b2f) | `` dotnetCorePackages.sdk_9_0: 9.0.316 -> 9.0.317 ``                                            |
| [`683995f3`](https://github.com/NixOS/nixpkgs/commit/683995f3864850638b1e6e8ea892481d9630afb5) | `` dotnetCorePackages.sdk_8_0: 8.0.423 -> 8.0.424 ``                                            |
| [`94da0e06`](https://github.com/NixOS/nixpkgs/commit/94da0e061900280831f4e87c0634925b7714c6fb) | `` dotnet/source/vmr.nix: fix global.json patching ``                                           |
| [`1a4b9d69`](https://github.com/NixOS/nixpkgs/commit/1a4b9d698cd997a6dc9a3d4fa6509a881fbf8a3e) | `` python3Packages.mypy-boto3-batch: 1.43.74 -> 1.43.76 ``                                      |
| [`19f89a91`](https://github.com/NixOS/nixpkgs/commit/19f89a917f1fd5235e0771988c4bb206f2106c38) | `` python3Packages.mypy-boto3-amplify: 1.43.67 -> 1.43.76 ``                                    |
| [`d56b8961`](https://github.com/NixOS/nixpkgs/commit/d56b896151e51cf6e99efc810b8690fc97d608f7) | `` proton-pass-cli: 2.3.1 -> 2.3.2 ``                                                           |
| [`d81a2634`](https://github.com/NixOS/nixpkgs/commit/d81a2634389d21a06335f3f3ea162f89493f169b) | `` aocl-utils: 5.3 -> 5.3.2 ``                                                                  |
| [`632e5071`](https://github.com/NixOS/nixpkgs/commit/632e507119c5ab4ee66d0a837f95d36e29deacae) | `` signal-desktop: 8.21.0 -> 8.24.0 ``                                                          |
| [`a9eb7f64`](https://github.com/NixOS/nixpkgs/commit/a9eb7f64267f91d052357649f79a7ed1b9e87e3f) | `` python3Packages.dm-control: 1.0.44 -> 1.0.45 ``                                              |
| [`06a21ded`](https://github.com/NixOS/nixpkgs/commit/06a21ded0b150acacc0d132ff61e6693d4c771de) | `` mujoco: 3.11.0 -> 3.12.0 ``                                                                  |
| [`bef0010c`](https://github.com/NixOS/nixpkgs/commit/bef0010cda64bc16c40589a511bff8e3ca3837ba) | `` complgen: 0.10.1 -> 0.11.0 ``                                                                |
| [`d3462811`](https://github.com/NixOS/nixpkgs/commit/d346281183cbff2f332f5d7adb1bec6645dfa824) | `` joplin-desktop: Add libnotify support ``                                                     |
| [`96cf09d9`](https://github.com/NixOS/nixpkgs/commit/96cf09d96bfa8647bbf16078cf1d89c35aa148ee) | `` noctalia: 5.0.0-beta.8 -> 5.0.0-beta.9 ``                                                    |
| [`fd9db746`](https://github.com/NixOS/nixpkgs/commit/fd9db746727df3dce4441a3a0d468adbe521c53f) | `` firecrawl-cli: 1.20.0 -> 1.21.1 ``                                                           |
| [`b0d904be`](https://github.com/NixOS/nixpkgs/commit/b0d904be601aabb580a62c3cb01b7fd3aff01069) | `` nvim-treesitter/update.py: source from derivation ``                                         |
| [`50cca7b8`](https://github.com/NixOS/nixpkgs/commit/50cca7b830be093f332bf7a84d9946f613e257ef) | `` nvim-treesitter/update.py: source from nvim-treesitter ``                                    |
| [`182953ef`](https://github.com/NixOS/nixpkgs/commit/182953ef4402afb5885de235bca9995e8a92ea08) | `` python3Packages.actron-neo-api: 0.5.12 -> 0.5.14 ``                                          |
| [`ad71705d`](https://github.com/NixOS/nixpkgs/commit/ad71705d2f7780f52fe6e27cccefb10202e1a925) | `` karakeep: fix worker crash by switching to nodejs_22 ``                                      |
| [`0b0a03ad`](https://github.com/NixOS/nixpkgs/commit/0b0a03ad85ff1c2b2afcd3c6af80ca851dbd47d8) | `` python3Packages.vsure: 2.10.0 -> 2.10.1 ``                                                   |
| [`74af9be5`](https://github.com/NixOS/nixpkgs/commit/74af9be5f70fcad5486b2515accf42ec14c84389) | `` kyverno: 1.18.2 -> 1.19.0 ``                                                                 |
| [`6830028b`](https://github.com/NixOS/nixpkgs/commit/6830028ba0ab39952102d47e1bff7438c2af52aa) | `` lxgw-neoxihei: 1.304 -> 1.305 ``                                                             |
| [`d8cc4662`](https://github.com/NixOS/nixpkgs/commit/d8cc4662f1aa9cecd143052250d6cd7cb4c0aa55) | `` python3Packages.curl-cffi: remove workaround ``                                              |
| [`9da1a5ec`](https://github.com/NixOS/nixpkgs/commit/9da1a5ec6c87b0def6717f4c99ca499fe95ba213) | `` curl-impersonate: fix dylib install name on darwin ``                                        |
| [`a2c92186`](https://github.com/NixOS/nixpkgs/commit/a2c9218677d081a6d0100af56fb761aebf1bfb7d) | `` kdePackages.kwin-x11: restore dependency specification ``                                    |
| [`c29b00c2`](https://github.com/NixOS/nixpkgs/commit/c29b00c2b6abd531c31df435d8be3b27a38a27d6) | `` par2cmdline-turbo: 1.4.0 -> 1.5.0 ``                                                         |
| [`e03b61bb`](https://github.com/NixOS/nixpkgs/commit/e03b61bb0878057e2e8911e2372c329e061c6ae8) | `` music-assistant: update providers, run apple_music tests ``                                  |
| [`0d1d643c`](https://github.com/NixOS/nixpkgs/commit/0d1d643c605f31fc32d87535ee5ad3ce19ac7bc3) | `` sampo: 0.19.0 -> 0.20.0 ``                                                                   |
| [`96ed975d`](https://github.com/NixOS/nixpkgs/commit/96ed975d598c535e2004d1db5dd903f697d122e7) | `` linuxKernel.kernels.linux_zen: 7.1.8 -> 7.1.9 ``                                             |
| [`d479b90e`](https://github.com/NixOS/nixpkgs/commit/d479b90eae0986ec7c5ea8c64967cd83e3bf64a2) | `` prometheus-mongodb-exporter: 0.52.0 -> 0.53.0 ``                                             |
| [`5c99cd87`](https://github.com/NixOS/nixpkgs/commit/5c99cd87cd447ccd585c32e3ae563f31586af8f0) | `` testkube: 2.12.1 -> 2.12.2 ``                                                                |
| [`d567488a`](https://github.com/NixOS/nixpkgs/commit/d567488aaacb1505e55358408bd2af117b427389) | `` turbovnc: 3.3 -> 3.3.1 ``                                                                    |
| [`e858b8e7`](https://github.com/NixOS/nixpkgs/commit/e858b8e7ca5247eb02d9db843cd76e36b56e12e2) | `` clj-kondo: fix startup crash with GraalVM >= 25.1 ``                                         |
| [`179609d7`](https://github.com/NixOS/nixpkgs/commit/179609d7956359a84bf2c0b5b5ce14c740bee6e4) | `` better-commits: 1.24.0 -> 1.26.0 ``                                                          |
| [`bfe57d67`](https://github.com/NixOS/nixpkgs/commit/bfe57d67f78c32c6827bcd4e5c28a8a91d818eca) | `` wgo: 0.6.4 -> 0.7.1 ``                                                                       |
| [`63159bf2`](https://github.com/NixOS/nixpkgs/commit/63159bf2e038d41ece7bdd394537203d2c1a40c0) | `` plezy: 2.13.0 -> 2.16.0 ``                                                                   |
| [`84ffdf13`](https://github.com/NixOS/nixpkgs/commit/84ffdf13c481e4b2db8bb2c9d6155bbf1208d9aa) | `` python3Packages.alibabacloud-credentials: 1.0.11 -> 1.0.12 ``                                |
| [`9b587655`](https://github.com/NixOS/nixpkgs/commit/9b5876556172f5bf244b58c2921d6d5daa6da14d) | `` devin-desktop: 3.7.16 -> 3.7.25 ``                                                           |
| [`c8979daa`](https://github.com/NixOS/nixpkgs/commit/c8979daa0e6106feacf297e75128ee7bd630fc0c) | `` python3Packages.soundcloud-v2: relax deps for curl-cffi ``                                   |
| [`cc83ff35`](https://github.com/NixOS/nixpkgs/commit/cc83ff3525f0af9d0b9099a4103745453648a39f) | `` yt-dlp: 2026.07.04 -> 2026.08.19 ``                                                          |
| [`6b7d409d`](https://github.com/NixOS/nixpkgs/commit/6b7d409df97e10ad131efc77ddb7163e53b8f6f0) | `` python3Packages.curl-cffi: 0.15.0 -> 0.16.0 ``                                               |
| [`f9f52c78`](https://github.com/NixOS/nixpkgs/commit/f9f52c783c7b0d5afbc60f26d8d29a6b7abb62f9) | `` chromium: don't show misleading Terms of Service dialog on first run ``                      |
| [`58829b3f`](https://github.com/NixOS/nixpkgs/commit/58829b3f92b18eafc8367e277fb0f8b65076c6af) | `` likwid: 5.5.1 -> 5.5.2 ``                                                                    |
| [`b7319be6`](https://github.com/NixOS/nixpkgs/commit/b7319be626132ab77a7871f3a639227baf5a78a9) | `` reproxy: modernize ``                                                                        |
| [`f6356416`](https://github.com/NixOS/nixpkgs/commit/f63564163d49383eaddf89f826c528802840dd7f) | `` golangci-lint: 2.12.2 -> 2.13.0 ``                                                           |
| [`00363857`](https://github.com/NixOS/nixpkgs/commit/00363857d3289940f522ca31a4ae41f224471cb5) | `` venera: drop ``                                                                              |
| [`5284f04b`](https://github.com/NixOS/nixpkgs/commit/5284f04bb0d33d148444755d99532068ec8c1645) | `` infisical: 0.43.110 -> 0.43.123 ``                                                           |
| [`1626a2e0`](https://github.com/NixOS/nixpkgs/commit/1626a2e097732de39347c05f2f84396ef442eaa1) | `` go-tools: 2026.1 -> 2026.2 ``                                                                |
| [`38552f41`](https://github.com/NixOS/nixpkgs/commit/38552f4113ffe567d2a16d8d2a6407d6b42a7ee7) | `` libreoffice: 26.2.1.2, 25.8.5.2 -> 26.2.5.2 ``                                               |
| [`878796b6`](https://github.com/NixOS/nixpkgs/commit/878796b6149d4d0fd9c4bb4968bca8d6e3d4667a) | `` tailwindcss-language-server: 0.14.29 -> 0.16.0 ``                                            |
| [`3bf7739b`](https://github.com/NixOS/nixpkgs/commit/3bf7739b00c99157d510e13c01249523dc5c8ae7) | `` vm-curator: init at 1.4.0 ``                                                                 |
| [`3314e112`](https://github.com/NixOS/nixpkgs/commit/3314e11296646958535ce6bfccf9f7ae2039c47d) | `` scx.rustscheds: 1.1.2 -> 1.1.3 ``                                                            |
| [`ad198d77`](https://github.com/NixOS/nixpkgs/commit/ad198d77075363289fbb510110a0769f8463079a) | `` gum: 0.17.0 -> 2.0.0 ``                                                                      |
| [`3f862d8a`](https://github.com/NixOS/nixpkgs/commit/3f862d8a232ef1f6185157648ed9749f1ba3da88) | `` python3Packages.griffecli: 2.1.0 -> 2.2.0 ``                                                 |
| [`7d603af3`](https://github.com/NixOS/nixpkgs/commit/7d603af3b3689417a70a4782f8562a63ebb2c96f) | `` python3Packages.griffelib: 2.1.0 -> 2.2.0 ``                                                 |
| [`a3129502`](https://github.com/NixOS/nixpkgs/commit/a312950240ae11cd508605f632ea0adbe79b9912) | `` python3Packages.deepmerge: 2.1.0 -> 3.0 ``                                                   |
| [`11b02ba5`](https://github.com/NixOS/nixpkgs/commit/11b02ba59bab41388d4ced609549faeaaa91e086) | `` evcc: 0.313.3 -> 0.314.2 ``                                                                  |
| [`686ab6ac`](https://github.com/NixOS/nixpkgs/commit/686ab6acee7c651ff8be41890ec2aadf84c456c8) | `` python3Packages.markdown-inline-graphviz-extension: use `finalAttrs` pattern ``              |
| [`e9f97240`](https://github.com/NixOS/nixpkgs/commit/e9f97240ad51633ebfa5428477bf3fc4917ead00) | `` python3Packages.markdown-inline-graphviz-extension: fix build ``                             |
| [`872a151d`](https://github.com/NixOS/nixpkgs/commit/872a151da32581dc52edd8de82f301af1b023603) | `` python3Packages.markdown-inline-graphviz-extension: rename ``                                |
| [`5487f7fd`](https://github.com/NixOS/nixpkgs/commit/5487f7fdc5c07498f44ea259b974a3bda359e398) | `` python3Pakcages.pcapy-ng: modernize ``                                                       |
| [`63ceec08`](https://github.com/NixOS/nixpkgs/commit/63ceec08859b5e68df8a700074b28a846f474bf9) | `` cargo-lambda: zig_0_13 -> zig ``                                                             |
| [`d8302fec`](https://github.com/NixOS/nixpkgs/commit/d8302fecaef22778ba26d19d8c3bf721c7daca4c) | `` prometheus-knot-exporter: 3.5.6 -> 3.5.7 ``                                                  |
| [`c94a33a5`](https://github.com/NixOS/nixpkgs/commit/c94a33a59c46b27f4ffbecc94545da89d37dc2dd) | `` python3Packages.libknot: 3.5.6 -> 3.5.7 ``                                                   |
| [`0843d551`](https://github.com/NixOS/nixpkgs/commit/0843d551442ebaf408ce9cb706fad588e8742608) | `` python3Packages.django-js-asset: 4.0.1 -> 4.0.2 ``                                           |
| [`9da05ef5`](https://github.com/NixOS/nixpkgs/commit/9da05ef561b44f46b4fd3582eff5df4c3694f6d6) | `` rshim-user-space: 2.7.3 -> 2.8.5 ``                                                          |
| [`a5e44926`](https://github.com/NixOS/nixpkgs/commit/a5e44926733b7603db1db043d7fb79694e5fc7a3) | `` rocqPackages.coqeal: use mkRocqDerivation ``                                                 |
| [`d466116a`](https://github.com/NixOS/nixpkgs/commit/d466116ac4c270592b54dc7c648c562af8a00eb0) | `` rocqPackages.multinomials: use mkRocqDerivation ``                                           |
| [`b15e19c0`](https://github.com/NixOS/nixpkgs/commit/b15e19c0932c53dcaa06a526f1a4e02507cac077) | `` rocqPackages.odd-order: use mkRocqDerivation ``                                              |
| [`294fffaf`](https://github.com/NixOS/nixpkgs/commit/294fffafd6485d03575c63840b109ddf91250bcd) | `` rocqPackages.fourcolor: use mkRocqDerivation ``                                              |
| [`2eb3e141`](https://github.com/NixOS/nixpkgs/commit/2eb3e141eecdff1e88ebcb641fd807dca7a1a2b1) | `` forgejo: 16.0.2 -> 16.0.3 ``                                                                 |
| [`71d3df2e`](https://github.com/NixOS/nixpkgs/commit/71d3df2e8dd44d9fa80a6cfba922140de43321ff) | `` forgejo-lts: 15.0.6 -> 15.0.7 ``                                                             |
| [`f304b4ea`](https://github.com/NixOS/nixpkgs/commit/f304b4ea2144658d14f0133ac1cfe3cb90b6f859) | `` ytdownloader: pin electron version ``                                                        |
| [`71c1f463`](https://github.com/NixOS/nixpkgs/commit/71c1f463176cd151af1ba20f7459a59e4709d416) | `` sharedown: pin electron version ``                                                           |
| [`7f6527d3`](https://github.com/NixOS/nixpkgs/commit/7f6527d354e7134479bb912d405e3942d2fd76ce) | `` session-desktop: mark as broken ``                                                           |
| [`a4749ee3`](https://github.com/NixOS/nixpkgs/commit/a4749ee3c380563fd8fa8b4d5507deebe74ba3be) | `` musicfree-desktop: pin electron version ``                                                   |
| [`f058b2fb`](https://github.com/NixOS/nixpkgs/commit/f058b2fb01364174ca84930ec9ee46542cf3e799) | `` solidtime-desktop: pin electron version ``                                                   |
| [`ec42ba60`](https://github.com/NixOS/nixpkgs/commit/ec42ba605327c3a60c7189bab8233f691e6a82e4) | `` electron{,-bin,-chromedriver}: 41 -> 43 ``                                                   |
| [`20d5d180`](https://github.com/NixOS/nixpkgs/commit/20d5d180f4693b60faba36c0c9b7ed795e482a57) | `` python3Packages.pcapy-ng: 1.0.9 -> 2.1.0 ``                                                  |
| [`c0d65285`](https://github.com/NixOS/nixpkgs/commit/c0d652854c708dee080c512292449766f6fbc55d) | `` reindeer: 2026.08.10.00 -> 2026.08.17.00 ``                                                  |
| [`cd15b07f`](https://github.com/NixOS/nixpkgs/commit/cd15b07f7b52d02032994193a08b6e23fdb2f469) | `` open-scq30: fix missing icons ``                                                             |
| [`8f97ef9c`](https://github.com/NixOS/nixpkgs/commit/8f97ef9c610741b1158d40042ae7c066ac61f341) | `` python3Packages.zwave-js-server-python: 0.73.0 -> 0.73.1 ``                                  |
| [`61062aff`](https://github.com/NixOS/nixpkgs/commit/61062aff1c4eaee515591dbe73660a2f32e35e21) | `` par2cmdline: 0.8.1 -> 1.3.0 ``                                                               |
| [`607ff3ea`](https://github.com/NixOS/nixpkgs/commit/607ff3ea3b86a1d68d377816608db79e9246ae89) | `` zellij-unwrapped: 0.44.3 -> 0.45.0 ``                                                        |
| [`cbaa8a6a`](https://github.com/NixOS/nixpkgs/commit/cbaa8a6af3081c74510240068d9a1380d99aeda1) | `` eliza: 0-unstable-2026-08-10 -> 0-unstable-2026-08-17 ``                                     |
| [`f2d7d4cd`](https://github.com/NixOS/nixpkgs/commit/f2d7d4cd1fa007f8d59594022b365b80d28a920e) | `` komodo: 2.3.1 -> 2.3.2 ``                                                                    |
| [`256bd460`](https://github.com/NixOS/nixpkgs/commit/256bd460bcf43a3d1b680edfab84679a7789c8eb) | `` postgresqlPackages.omnigres: unpin clang_18 ``                                               |
| [`b38e8b13`](https://github.com/NixOS/nixpkgs/commit/b38e8b1347ea286dd64305f3ec09c81b6420d878) | `` electron-source.electron_43: 43.2.0 -> 43.4.1 ``                                             |
| [`4a9d9b4c`](https://github.com/NixOS/nixpkgs/commit/4a9d9b4cd29831e59b9af199a67d20a7a8e8409c) | `` electron-source.electron_42: 42.7.1 -> 42.9.3 ``                                             |
| [`94040b78`](https://github.com/NixOS/nixpkgs/commit/94040b7892d466c3c791123d3bd3d000ae787272) | `` electron-source.electron_41: 41.10.3 -> 41.10.6 ``                                           |
| [`6f59e59a`](https://github.com/NixOS/nixpkgs/commit/6f59e59a65c9553b24e930d818dc1f43ae3a5020) | `` electron-chromedriver_43: 43.2.0 -> 43.4.1 ``                                                |
| [`dc26b579`](https://github.com/NixOS/nixpkgs/commit/dc26b5791a493724361058808d439e190f4c30e1) | `` electron_43-bin: 43.2.0 -> 43.4.1 ``                                                         |
| [`12bc6f35`](https://github.com/NixOS/nixpkgs/commit/12bc6f355a12344649d4529a38347093a9848f0f) | `` electron-chromedriver_42: 42.7.1 -> 42.9.3 ``                                                |
| [`1e6dbaaf`](https://github.com/NixOS/nixpkgs/commit/1e6dbaaf5cdb5ce6f2df504070067078d769c9f0) | `` electron_42-bin: 42.7.1 -> 42.9.3 ``                                                         |
| [`905fb91d`](https://github.com/NixOS/nixpkgs/commit/905fb91d9d21a178b715069081b3807ef8564013) | `` electron-chromedriver_41: 41.10.3 -> 41.10.6 ``                                              |
| [`96e99613`](https://github.com/NixOS/nixpkgs/commit/96e99613029766a56474684aff621650461e1b2c) | `` electron_41-bin: 41.10.3 -> 41.10.6 ``                                                       |
| [`e25aa050`](https://github.com/NixOS/nixpkgs/commit/e25aa050d59fbb2822a1cda47c7205c69ae37824) | `` maintainers: add mroboff ``                                                                  |
| [`0ca322f6`](https://github.com/NixOS/nixpkgs/commit/0ca322f62b672fd6d4cd4b97a4d9f7dcbb67cc54) | `` python3Packages.zipstream-ng: 1.9.2 -> 1.9.3 ``                                              |
| [`ea0fc1d4`](https://github.com/NixOS/nixpkgs/commit/ea0fc1d424794352a99998c9fe2772d711a834f5) | `` gitlab: 19.2.4 -> 19.3.0 ``                                                                  |
| [`00e1cd17`](https://github.com/NixOS/nixpkgs/commit/00e1cd17beb0895ccafa0b2216c27aa95c6383d5) | `` eilmeldung: remove unnecessary env variable outside of env ``                                |
| [`886e3523`](https://github.com/NixOS/nixpkgs/commit/886e3523149f8ff06ee8e9d14b06315a9d6cb893) | `` mesa: 26.2.0 -> 26.2.1 ``                                                                    |
| [`77cca2ca`](https://github.com/NixOS/nixpkgs/commit/77cca2ca04dd1818d0225b9b9320c84f47632394) | `` terraform-providers.jianyuan_sentry: 0.15.4 -> 0.15.5 ``                                     |
| [`90aff9bb`](https://github.com/NixOS/nixpkgs/commit/90aff9bbacda5dcf720d50104f4f73b91a91d453) | `` wails: 2.14.0 -> 2.15.0 ``                                                                   |
| [`4e133797`](https://github.com/NixOS/nixpkgs/commit/4e133797ae4d8dc6c0b5f46a2470520aab7e6a17) | `` xsstrike: modernize ``                                                                       |
| [`e6434ba3`](https://github.com/NixOS/nixpkgs/commit/e6434ba3fec6f3d9b18f3bbfcd6cfd0c51cd5980) | `` xsstrike: init at 3.1.6 ``                                                                   |
| [`6607ac0b`](https://github.com/NixOS/nixpkgs/commit/6607ac0b7938c52c80471bfb141d3d966ad9d3d7) | `` home-assistant-matter-hub: 2.0.54 -> 2.0.55 ``                                               |
| [`f1cb0319`](https://github.com/NixOS/nixpkgs/commit/f1cb03195939d72f31a46e7ddbca7e28c15fe3e0) | `` nixos/systemd/nspawn: allow unit settings added since systemd 250 ``                         |
| [`496654bc`](https://github.com/NixOS/nixpkgs/commit/496654bc3c50f3baf4f6448580ba8abe98a28185) | `` python3Packages.tencentcloud-sdk-python: 3.1.160 -> 3.1.161 ``                               |

*... and 3072 more commits (truncated)*